### PR TITLE
Refactor Attributes into Sprite Entity

### DIFF
--- a/src/gameplay/characters/components.rs
+++ b/src/gameplay/characters/components.rs
@@ -74,6 +74,9 @@ pub struct CharacterSpriteBundle {
     pub animatable: Animatable,
     pub facing: Facing,
     pub character_sprite: CharacterSprite,
+    // Character Attributes
+    pub character_equips: CharacterEquips,
+    pub character_stats: CharacterStats,
 }
 
 impl CharacterSpriteBundle {
@@ -93,22 +96,7 @@ impl CharacterSpriteBundle {
             animatable: animatable,
             facing: Facing::default(),
             character_sprite: CharacterSprite { centering_transform: centering_transform },
-        }
-    }
-}
-
-#[derive(Bundle)]
-pub struct CharacterAttributesBundle {
-    pub character_equips: CharacterEquips,
-    pub character_stats: CharacterStats,
-}
-
-impl Default for CharacterAttributesBundle {
-    fn default() -> Self {
-        Self {
-            character_equips: CharacterEquips {
-                weapon: BARE_FISTS
-            },
+            character_equips: CharacterEquips { weapon: BARE_FISTS },
             character_stats: CharacterStats { ..Default::default() },
         }
     }

--- a/src/gameplay/characters/enemies/test_enemy.rs
+++ b/src/gameplay/characters/enemies/test_enemy.rs
@@ -2,13 +2,10 @@ use crate::loading::test_enemy::TestEnemySpriteAssets;
 use crate::gameplay::characters::components::{
     CharacterPhysicsBundle,
     CharacterSpriteBundle,
-    CharacterAttributesBundle,
 };
 use crate::gameplay::characters::enemies::BossPhysics;
 use crate::gameplay::resources::ScreenBottomLeft;
 use crate::animations::{ Animatable, AnimationConfig };
-use crate::gameplay::items::CharacterEquips;
-use crate::gameplay::items::weapons::TESTING_SWORDS;
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
@@ -36,7 +33,7 @@ pub fn spawn_test_enemy(
             BossPhysics,
         ))
         .with_children(|children| {
-            children.spawn(   // Animations, appearance and hitbox
+            children.spawn(   // Animations, appearance, hitbox and attributes
                 CharacterSpriteBundle::new(
                     Transform::from_translation(Vec3::new(
                         4.0, 8.0, 0.
@@ -45,14 +42,6 @@ pub fn spawn_test_enemy(
                     enemy_animatable,
                     Vec3::new(4.0, 8.0, 0.0)
                 ),
-            );
-            children.spawn(   // Gameplay attributes and inventory
-                CharacterAttributesBundle {
-                    character_equips: CharacterEquips { 
-                        weapon: TESTING_SWORDS
-                    },
-                    ..Default::default()
-                }
             );
         });
 }

--- a/src/gameplay/characters/player.rs
+++ b/src/gameplay/characters/player.rs
@@ -2,7 +2,6 @@ use crate::loading::swordsmaster::SwordsMasterSpriteAssets;
 use crate::gameplay::characters::components::{
     CharacterPhysicsBundle,
     CharacterSpriteBundle,
-    CharacterAttributesBundle,
 };
 use crate::gameplay::characters::systems::movement::{
     player_grounded_movement,
@@ -76,7 +75,7 @@ fn spawn_player(
             PlayerPhysics,
         ))
         .with_children(|children| {
-            children.spawn((   // Animations, appearance and hitbox
+            children.spawn((   // Animations, appearance, hitbox and attributes
                 CharacterSpriteBundle::new(
                     Transform::from_translation(Vec3::new(
                         17.0, 3.0, 0.
@@ -87,14 +86,6 @@ fn spawn_player(
                 ),
                 PlayerSprite
             ));
-            children.spawn(   // Gameplay attributes and inventory
-                CharacterAttributesBundle {
-                    character_equips: CharacterEquips { 
-                        weapon: TESTING_SWORDS
-                    },
-                    ..Default::default()
-                }
-            );
         });
 }
 

--- a/src/gameplay/characters/systems/event.rs
+++ b/src/gameplay/characters/systems/event.rs
@@ -1,4 +1,6 @@
 use crate::gameplay::skills::events::ActivateSkillEvent;
+use crate::gameplay::items::CharacterEquips;
+use crate::gameplay::items::weapons::WeaponType;
 use bevy::prelude::*;
 
 
@@ -6,12 +8,12 @@ pub fn emit_ds_skill_activation<SourcePhysics: Component, SourceSprite: Componen
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut ev_activate_skill: EventWriter<ActivateSkillEvent>,
     physics_entity_query: Query<Entity, With<SourcePhysics>>,
-    sprite_entity_query: Query<Entity, With<SourceSprite>>,
+    sprite_entity_query: Query<(Entity, &CharacterEquips), With<SourceSprite>>,
 ) {
     // iterate in case the player controls multiple
     for physics_entity in physics_entity_query.iter() {
-        for sprite_entity in sprite_entity_query.iter() {
-            if keyboard_input.just_pressed(KeyCode::KeyZ) {
+        for (sprite_entity, equips) in sprite_entity_query.iter() {
+            if keyboard_input.just_pressed(KeyCode::KeyZ) && equips.weapon.weapon_type == WeaponType::DualSwords {
                 ev_activate_skill.send(ActivateSkillEvent {
                     skill: "ds_basic_attack".to_string(),
                     entity: physics_entity,


### PR DESCRIPTION
This allows for more ergonomic access of character attributes in systems that need to modify sprites or hitboxes (mostly the skills related systems). 

While it doesn't look as good, Bevy prefers flatter structures as working with entity hierarchies is difficult. Going forward, we will avoid hierarchies as much as possible. 